### PR TITLE
Fix HTML5 validation errors

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,6 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/category.html
+++ b/templates/category.html
@@ -12,9 +12,7 @@
             <article class="post-overview">
                 <h2><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h2>
                 <time datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b %d, %Y') }}</time>
-                <p class="excerpt">
-                    {{ article.summary }}
-                </p>
+                <div class="excerpt">{{ article.summary }}</div>
             </article>
 
             {% endfor %}

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -11,8 +11,7 @@
             {% endfor %}
         {% endif %}
         {% for title,url in CONTACTS %}
-            <li><a href="{{ url }}">{{ title|capitalize }}</h3>
-            </a></li>
+            <li><a href="{{ url }}">{{ title|capitalize }}</a></li>
         {% endfor %}
         {% include 'email.html' %}
     </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,9 +11,7 @@
             <article class="post-overview">
                 <h2><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h2>
                 <time datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b %d, %Y') }}</time>
-                <p class="excerpt">
-                    {{ article.summary }}
-                </p>
+                <div class="excerpt">{{ article.summary }}</div>
             </article>
 
             {% endfor %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-        <h1>Tag: {{ category }}. <small class="header-link"><a href="{{ SITEURL }}/tags">All Tags</a></small></h1></h1>
+        <h1>Tag: {{ category }}. <small class="header-link"><a href="{{ SITEURL }}/tags">All Tags</a></small></h1>
 
         <div class="post-list">
 
@@ -12,9 +12,7 @@
             <article class="post-overview">
                 <h2><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h2>
                 <time datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b %d, %Y') }}</time>
-                <p class="excerpt">
-                    {{ article.summary }}
-                </p>
+                <div class="excerpt">{{ article.summary }}</div>
             </article>
 
             {% endfor %}


### PR DESCRIPTION
Fixes a few HTML validation errors:

1. `X-UA-Compatible` meta tag, `chrome=1` not accepted (see also: [use htaccess instead of meta tag](https://css-tricks.com/forums/topic/x-ua-compatible-do-i-need-it/), [Retiring Chrome Frame ](http://blog.chromium.org/2013/06/retiring-chrome-frame.html)) -- *meta tag removed*
1. Nested paragraphs not allowed -- *use `div` instead for paragraph wrapper*
1. Two closing `</h1>` tags for `<h1>` tag -- *superfluous `</h1>` removed*
1. Illegal closing `</h3>` tag in footer -- *superfluous `</h3>` removed*

Tested with html5check.py, available from Mozilla's [html5-lint repository](https://github.com/mozilla/html5-lint).

## Side Note
Unfortunately, there are other HTML validation errors that come from Sphinx though, e.g.

* `The “tt” element is obsolete. Use CSS instead.` -- *when using [double-backtick markup](http://sphinx-doc.org/rest.html#inline-markup) for inline-verbatim*
* `The “frame” attribute on the “table” element is obsolete. Use CSS instead.`, `The “rules” attribute on the “table” element is obsolete. Use CSS instead.`, `The “valign” attribute on the “tbody” element is obsolete. Use CSS instead.` -- *when using a [footnote](http://sphinx-doc.org/rest.html#footnotes)*